### PR TITLE
Fix for is_available check

### DIFF
--- a/examples/domain-available.php
+++ b/examples/domain-available.php
@@ -39,7 +39,7 @@ if ($result['status'] !== Api_Odr::STATUS_SUCCESS) {
 
 $result = $result['response'];
 
-if ($result['available'] === true) {
+if ($result['is_available'] === true) {
     // Domain is available for registration
     echo 'Domain "'. $domainName .'" is available';
 


### PR DESCRIPTION
Check always returned domains as unavailable because it was using the wrong parameter to check for.
